### PR TITLE
WIP: Add Hydra in examples

### DIFF
--- a/deploy_nixos/nixos-deploy.sh
+++ b/deploy_nixos/nixos-deploy.sh
@@ -28,7 +28,7 @@ log() {
 }
 
 copyToTarget() {
-  NIX_SSHOPTS="${sshOpts[*]}" nix-copy-closure --to "$targetHost" "$1"
+  NIX_SSHOPTS="${sshOpts[*]}" nix-copy-closure --to "$targetHost" "$@"
 }
 
 # assumes that passwordless sudo is enabled on the server

--- a/deploy_nixos/nixos-instantiate.sh
+++ b/deploy_nixos/nixos-instantiate.sh
@@ -32,7 +32,7 @@ fi
 cd "$(readlink -f "$config_pwd")"
 
 # Run!
-echo "running: ${command[*]@Q}" >&2
+echo "running: $(env | grep NIX_PATH) ${command[*]@Q}" >&2
 drv_path=$("${command[@]}")
 
 if [[ "$drv_path" != /nix/store/*.drv ]]; then

--- a/deploy_nixos/unpack-keys.sh
+++ b/deploy_nixos/unpack-keys.sh
@@ -39,6 +39,7 @@ echo "unpacking $keys_file"
 for keyname in $(jq -S -r 'keys[]' "$keys_file"); do
   echo "unpacking: $keyname"
   jq -r ".$keyname" < "$keys_file" > "$keys_dir/$keyname"
+  chmod 0640 "$keys_dir/$keyname"
 done
 
 echo "unpacking done"

--- a/examples/hydra/README.md
+++ b/examples/hydra/README.md
@@ -1,0 +1,8 @@
+Setup a CI on an Openstack cloud for a Nix repository in one command: `terraform apply`
+
+Terraform will then
+- upload a NixOS base image on Glance (the Openstack image service)
+- boot two instances: one for Hydra, one for a Nix slave
+- configure this two instances by switching them to a new configuration
+- setup a declarative project (https://github.com/shlevy/declarative-hydra-example) through Hydra API.
+

--- a/examples/hydra/configuration.nix
+++ b/examples/hydra/configuration.nix
@@ -1,0 +1,66 @@
+{ modulesPath, config, pkgs, lib, ... }:
+
+let
+  cfg = config;
+
+  hydraPort = 3000;
+  hydraAdmin = "admin";
+  hydraAdminPassword = "VZE9uRiM4r0";
+
+  createDeclarativeProjectScript = pkgs.stdenv.mkDerivation {
+    name = "create-declarative-project";
+    unpackPhase = ":";
+    buildInputs = [ pkgs.makeWrapper ];
+    installPhase = "install -m755 -D ${./create-declarative-project.sh} $out/bin/create-declarative-project";
+    postFixup = ''wrapProgram "$out/bin/create-declarative-project" --prefix PATH ":" ${pkgs.stdenv.lib.makeBinPath [ pkgs.curl ]}'';
+  };
+
+in
+{
+  imports = [ "${toString modulesPath}/../maintainers/scripts/openstack/openstack-image.nix" ];
+
+  config =  {
+    networking.firewall.allowedTCPPorts = [ hydraPort ];
+
+    services.hydra = {
+      enable = true;
+      hydraURL = "example.com";
+      notificationSender = "root@localhost";
+      port = hydraPort;
+    };
+
+    nix = {
+      buildMachines = [{
+        hostName = "localhost";
+        systems = [ "x86_64-linux" ];
+      }];
+    };
+
+    # Create a admin user and configure a declarative project
+    systemd.services.hydra-post-init = {
+      serviceConfig = {
+        Type = "oneshot";
+        TimeoutStartSec = "60";
+      };
+      wantedBy = [ "multi-user.target" ];
+      after = ["hydra-server.service" ];
+      requires = [ "hydra-server.service" ];
+      environment = {
+        inherit (cfg.systemd.services.hydra-init.environment) HYDRA_DBI;
+      };
+      path = with pkgs; [ hydra netcat ];
+      script = ''
+        set -e
+        hydra-create-user ${hydraAdmin} --role admin --password ${hydraAdminPassword}
+        while ! nc -z localhost ${toString hydraPort}; do
+          sleep 1
+        done
+
+        export HYDRA_ADMIN_PASSWORD=${hydraAdminPassword}
+        export URL=http://localhost:${toString hydraPort} 
+        export DECL_VALUE="https://github.com/shlevy/declarative-hydra-example"
+        ${createDeclarativeProjectScript}/bin/create-declarative-project
+      '';
+    };
+  };
+}

--- a/examples/hydra/create-declarative-project.sh
+++ b/examples/hydra/create-declarative-project.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Usage example
+# URL=http://localhost:3000 ./create-declarative-project.sh
+
+set -euo pipefail
+
+HYDRA_ADMIN_USERNAME=${HYDRA_ADMIN_USERNAME:-admin}
+HYDRA_ADMIN_PASSWORD=${HYDRA_ADMIN_PASSWORD:-admin}
+URL=${URL:-http://localhost:3000}
+DECL_FILE=${DECL_FILE:-"spec.json"}
+DECL_TYPE=${DECL_TYPE:-"git"}
+DECL_VALUE=${DECL_VALUE:-"https://github.com/shlevy/declarative-hydra-example"}
+DECL_PROJECT_NAME=${DECL_TYPE:-"example"}
+
+mycurl() {
+  curl --fail --referer $URL -H "Accept: application/json" -H "Content-Type: application/json" $@
+}
+
+echo "Logging to $URL with user" "'"$HYDRA_ADMIN_USERNAME"'"
+cat >data.json <<EOF
+{ "username": "$HYDRA_ADMIN_USERNAME", "password": "$HYDRA_ADMIN_PASSWORD" }
+EOF
+mycurl -X POST -d '@data.json' $URL/login -c hydra-cookie.txt
+
+echo -e "\nCreating project:"
+cat >data.json <<EOF
+{
+  "displayname":"Declarative project example",
+  "enabled":"1",
+  "visible":"1",
+  "declfile": "$DECL_FILE",
+  "decltype":"$DECL_TYPE",
+  "declvalue":"$DECL_VALUE"
+}
+EOF
+cat data.json
+mycurl --silent -X PUT $URL/project/$DECL_PROJECT_NAME -d @data.json -b hydra-cookie.txt
+
+rm -f data.json hydra-cookie.txt

--- a/examples/hydra/main.tf
+++ b/examples/hydra/main.tf
@@ -1,0 +1,148 @@
+output "hydra_url" {
+  description = "Deployed Hydra URL"
+  value       = "http://${openstack_networking_floatingip_v2.hydra.address}:3000"
+}
+
+module "deploy_nixos_hydra" {
+  source = "../../deploy_nixos"
+  NIX_PATH = "nixpkgs=channel:nixos-18.09"
+  nixos_config = <<EOF
+    { lib, ...}:
+    {
+      imports = [ ./configuration.nix ];
+       nix.buildMachines = [{
+        hostName = "${openstack_networking_port_v2.slave.all_fixed_ips.0}";
+        sshUser = "root";
+        sshKey = "/var/keys/hydra_private_keys";
+        systems = [ "x86_64-linux" "builtin" ];
+        maxJobs = 1;
+      }];
+    }
+    EOF
+  target_user = "root"
+  target_host = "${openstack_networking_floatingip_v2.hydra.address}"
+  triggers = {
+    instance_id = "${openstack_compute_instance_v2.hydra.id}"
+  }
+
+  keys = {
+    hydra_private_key = "${openstack_compute_keypair_v2.hydra.private_key}"
+  }
+}
+
+module "deploy_nixos_slave" {
+  source = "../../deploy_nixos"
+  NIX_PATH = "nixpkgs=channel:nixos-18.09"
+  nixos_config = <<EOF
+    { lib, ...}:
+    {
+      imports = [ "/home/lewo/repos/nixpkgs/nixos/maintainers/scripts/openstack/openstack-image.nix" ];
+      users.extraUsers.root.openssh.authorizedKeys.keys = [ "${openstack_compute_keypair_v2.hydra.public_key}" ];
+    }
+    EOF
+  target_user = "root"
+  target_host = "${openstack_networking_floatingip_v2.slave.address}"
+  triggers = {
+    instance_id = "${openstack_compute_instance_v2.slave.id}"
+  }
+  keys = {
+    hydra_private_key = "${openstack_compute_keypair_v2.hydra.public_key}"
+  }
+}
+
+# This can be pretty long since the image is first downloaded locally
+# and then uploaded to Glance.
+resource "openstack_images_image_v2" "nixos" {
+  name   = "nixos-master"
+  # FIXME: Update this with an image coming from the nixos.org/nixos/download page :/
+  image_source_url = "https://cloud.abesis.fr/s/KrfPrQrbd5yW2tz/download"
+  container_format = "bare"
+  disk_format = "qcow2"
+}
+
+resource "openstack_compute_keypair_v2" "hydra" {
+  name = "hydra"
+}
+
+resource "openstack_networking_network_v2" "nixos" {
+  name = "nixos"
+  admin_state_up = "true"
+}
+
+resource "openstack_compute_secgroup_v2" "ssh" {
+  name = "ssh"
+  description = "ssh"
+  rule {
+    from_port = 22
+    to_port = 22
+    ip_protocol = "tcp"
+    cidr = "0.0.0.0/0"
+  }
+}
+
+resource "openstack_compute_secgroup_v2" "hydra" {
+  name = "hydra"
+  description = "hydra"
+  rule {
+    from_port = 3000
+    to_port = 3000
+    ip_protocol = "tcp"
+    cidr = "0.0.0.0/0"
+  }
+}
+
+resource "openstack_networking_subnet_v2" "nixos" {
+  name = "nixos"
+  network_id = "${openstack_networking_network_v2.nixos.id}"
+  cidr = "192.168.1.0/24"
+  ip_version = 4
+  enable_dhcp = true
+}
+
+resource "openstack_networking_port_v2" "hydra" {
+  network_id = "${openstack_networking_network_v2.nixos.id}"
+  admin_state_up = "true"
+  security_group_ids = ["${openstack_compute_secgroup_v2.ssh.id}", "${openstack_compute_secgroup_v2.hydra.id}"]
+  fixed_ip {
+    subnet_id = "${openstack_networking_subnet_v2.nixos.id}"
+  }
+}
+
+resource "openstack_networking_port_v2" "slave" {
+  network_id = "${openstack_networking_network_v2.nixos.id}"
+  admin_state_up = "true"
+  security_group_ids = ["${openstack_compute_secgroup_v2.ssh.id}"]
+  fixed_ip {
+    subnet_id = "${openstack_networking_subnet_v2.nixos.id}"
+  }
+}
+
+resource "openstack_networking_floatingip_v2" "hydra" {
+  pool = "public"
+  port_id = "${openstack_networking_port_v2.hydra.id}"
+}
+
+resource "openstack_networking_floatingip_v2" "slave" {
+  pool = "public"
+  port_id = "${openstack_networking_port_v2.slave.id}"
+}
+
+resource "openstack_compute_instance_v2" "hydra" {
+  name = "hydra"
+  image_name = "${openstack_images_image_v2.nixos.name}"
+  flavor_name = "s1.cw.small-1"
+  network {
+    port = "${openstack_networking_port_v2.hydra.id}"
+  }
+  key_pair = "rj45"
+}
+
+resource "openstack_compute_instance_v2" "slave" {
+  name = "slave"
+  image_name = "${openstack_images_image_v2.nixos.name}"
+  flavor_name = "s1.cw.small-1"
+  network {
+    port = "${openstack_networking_port_v2.slave.id}"
+  }
+  key_pair = "rj45"
+}


### PR DESCRIPTION
- Should I make it more configurable? It will then be more complicated (less suitable as a example)
- Should we add a GCP deployment to illustrate different backend support?

Todo:
- [ ] Use a base image coming from nixos.org (waiting for feedbacks on https://github.com/NixOS/nixos-homepage/issues/266)
- Would also be nice to upstream the declarative project creation in the hydra module