### PR TITLE
Use target caches

### DIFF
--- a/deploy_nixos/main.tf
+++ b/deploy_nixos/main.tf
@@ -60,7 +60,12 @@ locals {
   }
 
   target_system = ["--argstr", "system", "x86_64-linux"]
-  attr_path     = ["--attr", "system"]
+
+  extra_build_args = [
+    "--option", "substituters", "${data.external.nixos-instantiate.result["substituters"]}",
+    "--option", "trusted-public-keys", "${data.external.nixos-instantiate.result["trusted-public-keys"]}",
+    "${var.extra_build_args}"
+  ]
 }
 
 # used to detect changes in the configuration
@@ -71,7 +76,6 @@ data "external" "nixos-instantiate" {
     "${var.config != "" ? var.config : var.nixos_config}",
     "${var.config_pwd != "" ? var.config_pwd : "."}",
     "${local.target_system}",
-    "${local.attr_path}",
     "${var.extra_eval_args}",
   ]
 }
@@ -118,7 +122,7 @@ resource "null_resource" "deploy_nixos" {
       "${data.external.nixos-instantiate.result["drv_path"]}",
       "${var.target_user}@${var.target_host}",
       "switch",
-      "${var.extra_build_args}",
+      "${local.extra_build_args}",
     ]
 
     command = "ignoreme"

--- a/deploy_nixos/nixos-deploy.sh
+++ b/deploy_nixos/nixos-deploy.sh
@@ -32,7 +32,11 @@ copyToTarget() {
 
 # assumes that passwordless sudo is enabled on the server
 targetHostCmd() {
-  ssh "${sshOpts[@]}" "$targetHost" -- ./maybe-sudo.sh "$@"
+  # ${*@Q} escapes the arguments losslessly into space-separted quoted strings.
+  # `ssh` did not properly maintain the array nature of the command line,
+  # erroneously splitting arguments with internal spaces, even when using `--`.
+  # Tested with OpenSSH_7.9p1.
+  ssh "${sshOpts[@]}" "$targetHost" "./maybe-sudo.sh ${*@Q}"
 }
 
 ### Main ###


### PR DESCRIPTION
This makes evaluation a bit more flexible with respect to what is instantiated and which configuration options are used.