### PR TITLE
deploy_nixos: add var to pass IdentityFile to ssh

### DIFF
--- a/deploy_nixos/README.md
+++ b/deploy_nixos/README.md
@@ -89,6 +89,7 @@ see also:
 | nixos\_config | Path to a NixOS configuration | string | `` | no |
 | target\_host | DNS host to deploy to | string | - | yes |
 | target\_user | SSH user used to connect to the target_host | string | `root` | no |
+| ssh_private_key_file | SSH private key used to connect to the target host | string | unset | no |
 | triggers | Triggers for deploy | map | `<map>` | no |
 
 ## Outputs

--- a/deploy_nixos/main.tf
+++ b/deploy_nixos/main.tf
@@ -90,6 +90,7 @@ resource "null_resource" "deploy_nixos" {
     host  = var.target_host
     user  = var.target_user
     agent = true
+    timeout = "10s"
   }
 
   # copy the secret keys to the host

--- a/deploy_nixos/main.tf
+++ b/deploy_nixos/main.tf
@@ -7,6 +7,11 @@ variable "target_host" {
   description = "DNS host to deploy to"
 }
 
+variable "ssh_private_key_file" {
+  description = "Private key used to connect to the target_host"
+  default     = ""
+}
+
 variable "NIX_PATH" {
   description = "Allow to pass custom NIX_PATH. Ignored if `-`."
   default     = "-"
@@ -91,6 +96,7 @@ resource "null_resource" "deploy_nixos" {
     user  = var.target_user
     agent = true
     timeout = "10s"
+    private_key = var.ssh_private_key_file != "" ? file(var.ssh_private_key_file) : null
   }
 
   # copy the secret keys to the host
@@ -128,6 +134,7 @@ resource "null_resource" "deploy_nixos" {
         "${path.module}/nixos-deploy.sh",
         data.external.nixos-instantiate.result["drv_path"],
         "${var.target_user}@${var.target_host}",
+        var.ssh_private_key_file,
         "switch",
       ],
       local.extra_build_args

--- a/deploy_nixos/nixos-deploy.sh
+++ b/deploy_nixos/nixos-deploy.sh
@@ -18,6 +18,8 @@ sshOpts=(
   -o "StrictHostKeyChecking=no"
   -o "UserKnownHostsFile=/dev/null"
   -o "GlobalKnownHostsFile=/dev/null"
+  # interactive authentication is not possible
+  -o "BatchMode=yes"
 )
 
 ###  Argument parsing ###

--- a/deploy_nixos/nixos-deploy.sh
+++ b/deploy_nixos/nixos-deploy.sh
@@ -20,6 +20,24 @@ sshOpts=(
   -o "GlobalKnownHostsFile=/dev/null"
 )
 
+###  Argument parsing ###
+
+drvPath="$1"
+targetHost="$2"
+sshPrivateKeyFile="$3"
+action="$4"
+shift
+shift
+shift
+shift
+# remove the last argument
+set -- "${@:1:$(($# - 1))}"
+buildArgs+=("$@")
+
+if [ -n "${sshPrivateKeyFile}" ]; then
+    sshOpts+=( -o "IdentityFile=${sshPrivateKeyFile}" )
+fi
+
 ### Functions ###
 
 log() {
@@ -40,17 +58,6 @@ targetHostCmd() {
 }
 
 ### Main ###
-
-# Argument parsing
-drvPath="$1"
-targetHost="$2"
-action="$3"
-shift
-shift
-shift
-# remove the last argument
-set -- "${@:1:$(($# - 1))}"
-buildArgs+=("$@")
 
 # Ensure the local SSH directory exists
 mkdir -m 0700 -p "$HOME"/.ssh

--- a/deploy_nixos/nixos-deploy.sh
+++ b/deploy_nixos/nixos-deploy.sh
@@ -20,6 +20,8 @@ sshOpts=(
   -o "GlobalKnownHostsFile=/dev/null"
   # interactive authentication is not possible
   -o "BatchMode=yes"
+  # verbose output for easier debugging
+  -v
 )
 
 ###  Argument parsing ###


### PR DESCRIPTION
Sometimes `ssh` does not recognize the right pubkey to use (there’s an
upper limit on how many are checked), so we need a way to pass it
manually to terraform.