### PR TITLE
deploy_nixos: fix interpreter concat

### DIFF
--- a/deploy_nixos/main.tf
+++ b/deploy_nixos/main.tf
@@ -123,14 +123,14 @@ resource "null_resource" "deploy_nixos" {
   # do the actual deployment
   # do the actual deployment
   provisioner "local-exec" {
-    interpreter = [
-      "${path.module}/nixos-deploy.sh",
-      data.external.nixos-instantiate.result["drv_path"],
-      "${var.target_user}@${var.target_host}",
-      "switch",
-      local.extra_build_args,
-    ]
-
+    interpreter = concat([
+        "${path.module}/nixos-deploy.sh",
+        data.external.nixos-instantiate.result["drv_path"],
+        "${var.target_user}@${var.target_host}",
+        "switch",
+      ],
+      local.extra_build_args
+    )
     command = "ignoreme"
   }
 }


### PR DESCRIPTION
This was overlooked in the update to terraform 0.12 syntax.