### PR TITLE
deploy_nixos: increase ssh connection timeout

### DIFF
--- a/deploy_nixos/main.tf
+++ b/deploy_nixos/main.tf
@@ -95,7 +95,7 @@ resource "null_resource" "deploy_nixos" {
     host  = var.target_host
     user  = var.target_user
     agent = true
-    timeout = "10s"
+    timeout = "100s"
     private_key = var.ssh_private_key_file != "" ? file(var.ssh_private_key_file) : null
   }
 


### PR DESCRIPTION
I noticed that 10s is a bit too short, because the deployed machine
has to come up and the ssh connection terraform starts is waiting for
that.

Let’s increase the timeout to 100s, which should be plenty (but still
reasonable).