### PR TITLE
fix example: firewall and nixos_image_1809

### DIFF
--- a/examples/google/deploy_nixos.tf
+++ b/examples/google/deploy_nixos.tf
@@ -20,7 +20,11 @@ resource "google_compute_firewall" "deploy-nixos" {
     ports    = ["22"]
   }
 
-  source_tags = ["nixos"]
+  // To vm tagged with: nixos
+  target_tags   = ["nixos"]
+  direction     = "INGRESS"
+  // From anywhere.
+  source_ranges = ["0.0.0.0/0"]
 }
 
 resource "google_compute_instance" "deploy-nixos" {

--- a/examples/google/image_nixos.tf
+++ b/examples/google/image_nixos.tf
@@ -2,8 +2,8 @@
 # instance
 
 module "nixos_image_1809" {
-  source  = "../../google_image_nixos"
-  version = "18.09"
+  source        = "../../google_image_nixos"
+  nixos_version = "18.09"
 }
 
 // This instance is not very useful since it doesn't contain any


### PR DESCRIPTION
- fix nixos_image_1809 in example: version -> nixos_version
- fix firewall in the example
  the example was working with default network which allows all Ingress but
  would fail if the network was replaced with one which disallows all ingress.