### PR TITLE
fix deploy_nixos for cases when ssh_private_key_file is not defined

### DIFF
--- a/deploy_nixos/nixos-deploy.sh
+++ b/deploy_nixos/nixos-deploy.sh
@@ -38,7 +38,7 @@ shift
 set -- "${@:1:$(($# - 1))}"
 buildArgs+=("$@")
 
-if [ -n "${sshPrivateKeyFile}" ]; then
+if [ -n "${sshPrivateKeyFile}" && "${sshPrivateKeyFile}" != "-"  ]; then
     sshOpts+=( -o "IdentityFile=${sshPrivateKeyFile}" )
 fi
 


### PR DESCRIPTION
when `var.ssh_private_key_file` was set to empty string it would get
filtered out from the args passed `nixos-deploy.sh` executed via
local-exec provisioner, which resulted in `sshPrivateKeyFile=action`
and `action` being set to first of the `extra_build_args`

when running the example code I got the following error:

```
module.deploy_nixos.null_resource.deploy_nixos (local-exec): Executing: ["../../deploy_nixos/nixos-deploy.sh" "/nix/store/gbsapdbgwzj2qbmb531pkq5chp9fdx17-nixos-system-unnamed-18.09.2574.a7e559a5504.drv" "root@34.70.2.8" "switch" "--option" "substituters" "https://cache.nixos.org/" "--option" "trusted-public-keys" "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" "ignoreme"]
module.deploy_nixos.null_resource.deploy_nixos (local-exec): --- building nix code
module.deploy_nixos.null_resource.deploy_nixos (local-exec): error: getting status of '/Users/adriangierakowski/SourceCode/terraform-nixos2/examples/google/substituters': No such file or directory
```