### PR TITLE
deploy_nixos: Add var.ssh_agent

### DIFF
--- a/deploy_nixos/main.tf
+++ b/deploy_nixos/main.tf
@@ -12,6 +12,12 @@ variable "ssh_private_key_file" {
   default     = "-"
 }
 
+variable "ssh_agent" {
+  description = "Whether to use an SSH agent"
+  type        = bool
+  default     = true
+}
+
 variable "NIX_PATH" {
   description = "Allow to pass custom NIX_PATH. Ignored if `-`."
   default     = "-"
@@ -95,7 +101,7 @@ resource "null_resource" "deploy_nixos" {
     type        = "ssh"
     host        = var.target_host
     user        = var.target_user
-    agent       = true
+    agent       = var.ssh_agent
     timeout     = "100s"
     private_key = local.ssh_private_key_file != "-" ? file(var.ssh_private_key_file) : null
   }


### PR DESCRIPTION
Allow disabling the use of an ssh agent. An ssh agent is not needed when using a passwordless key and does not seem feasible on terraform cloud.