### PR TITLE
deploy_nixos/nixos-deploy.sh: fix ControlPersist timeout

### DIFF
--- a/deploy_nixos/nixos-deploy.sh
+++ b/deploy_nixos/nixos-deploy.sh
@@ -10,10 +10,11 @@ buildArgs=(
   --option extra-binary-caches https://cache.nixos.org/
 )
 profile=/nix/var/nix/profiles/system
+# will be set later
+controlPath=
 sshOpts=(
   -o "ControlMaster=auto"
   -o "ControlPersist=60"
-  -o "ControlPath=${HOME}/.ssh/deploy_nixos_%C"
   # Avoid issues with IP re-use. This disable TOFU security.
   -o "StrictHostKeyChecking=no"
   -o "UserKnownHostsFile=/dev/null"
@@ -61,10 +62,30 @@ targetHostCmd() {
   ssh "${sshOpts[@]}" "$targetHost" "./maybe-sudo.sh ${*@Q}"
 }
 
+# Setup a temporary ControlPath for this session. This speeds-up the
+# operations by not re-creating SSH sessions between each command. At the end
+# of the run, the session is forcefully terminated.
+setupControlPath() {
+  controlPath=$(mktemp)
+  sshOpts+=(
+    -o "ControlPath=$controlPath"
+  )
+  cleanupControlPath() {
+    local ret=$?
+    # Avoid failing during the shutdown
+    set +e
+    # Close ssh multiplex-master process gracefully
+    log "closing persistent ssh-connection"
+    ssh "${sshOpts[@]}" -O stop "$targetHost"
+    rm -f "$controlPath"
+    exit "$ret"
+  }
+  trap cleanupControlPath EXIT
+}
+
 ### Main ###
 
-# Ensure the local SSH directory exists
-mkdir -m 0700 -p "$HOME"/.ssh
+setupControlPath
 
 if [[ "${buildOnTarget:-false}" == true ]]; then
 
@@ -97,8 +118,3 @@ targetHostCmd "$outPath/bin/switch-to-configuration" "$action"
 # Cleanup previous generations
 log "collecting old nix derivations"
 targetHostCmd "nix-collect-garbage" "-d"
-
-# Close ssh multiplex-master process gracefully
-log "closing persistent ssh-connection"
-sshOpts+=( -O "stop" )
-ssh "${sshOpts[@]}" "$targetHost"

--- a/deploy_nixos/nixos-deploy.sh
+++ b/deploy_nixos/nixos-deploy.sh
@@ -97,3 +97,8 @@ targetHostCmd "$outPath/bin/switch-to-configuration" "$action"
 # Cleanup previous generations
 log "collecting old nix derivations"
 targetHostCmd "nix-collect-garbage" "-d"
+
+# Close ssh multiplex-master process gracefully
+log "closing persistent ssh-connection"
+sshOpts+=( -O "stop" )
+ssh "${sshOpts[@]}" "$targetHost"


### PR DESCRIPTION
fixes #20 by gracefully closing the multiplexing master process gracefully.

> https://man.openbsd.org/ssh
> Control an active connection multiplexing master process. When the -O option is specified, the ctl_cmd argument is interpreted and passed to the master process. Valid commands are: “check” (check that the master process is running), “forward” (request forwardings without command execution), “cancel” (cancel forwardings), “exit” (request the master to exit), and “stop” (request the master to stop accepting further multiplexing requests).
