### PR TITLE
deploy_nixos/unpack-keys.sh: chown the keys to root:keys

### DIFF
--- a/deploy_nixos/unpack-keys.sh
+++ b/deploy_nixos/unpack-keys.sh
@@ -40,6 +40,7 @@ for keyname in $(jq -S -r 'keys[]' "$keys_file"); do
   echo "unpacking: $keyname"
   jq -r ".\"$keyname\"" < "$keys_file" > "$keys_dir/$keyname"
   chmod 0640 "$keys_dir/$keyname"
+  chown root:keys "$keys_dir/$keyname"
 done
 
 echo "unpacking done"


### PR DESCRIPTION
They were `root:root` before, so they couldn’t be read by the `keys`
group as intended.