### PR TITLE
Fix syntax warning with terraform 0.13

### DIFF
--- a/aws_image_nixos/README.md
+++ b/aws_image_nixos/README.md
@@ -18,7 +18,7 @@ supported.
     }
 
     resource "aws_instance" "example" {
-      ami           = "${module.nixos_image_1903.ami}"
+      ami           = module.nixos_image_1903.ami
       instance_type = "t2.micro"
 
       ...

--- a/deploy_nixos/main.tf
+++ b/deploy_nixos/main.tf
@@ -107,7 +107,7 @@ data "external" "nixos-instantiate" {
     var.config_pwd != "" ? var.config_pwd : ".",
     # end of positional arguments
     # start of pass-through arguments
-    "--argstr", "system", "${var.target_system}"
+    "--argstr", "system", var.target_system
     ],
     var.extra_eval_args,
   )
@@ -162,7 +162,7 @@ resource "null_resource" "deploy_nixos" {
       data.external.nixos-instantiate.result["drv_path"],
       data.external.nixos-instantiate.result["out_path"],
       "${var.target_user}@${var.target_host}",
-      "${var.target_port}",
+      var.target_port,
       local.build_on_target,
       local.ssh_private_key_file,
       "switch",

--- a/google_image_nixos/README.md
+++ b/google_image_nixos/README.md
@@ -22,7 +22,7 @@ resource "google_compute_instance" "example" {
 
   boot_disk {
     initialize_params {
-      image = "${module.nixos_image_1809.self_link}"
+      image = module.nixos_image_1809.self_link
     }
   }
 


### PR DESCRIPTION
Terraform 0.13 will throw the following warning:

> Warning: Interpolation-only expressions are deprecated
>   on .terraform/modules/dbpool.deploy_nixos/deploy_nixos/main.tf line
>   104, in data "external" "nixos-instantiate":
>    104:     "--argstr", "system", "${var.target_system}"
>    Terraform 0.11 and earlier required all non-constant expressions to be
>    provided via interpolation syntax, but this pattern is now deprecated. To
>    silence this warning, remove the "${ sequence from the start and the }"
> sequence from the end of this expression, leaving just the inner expression.
> Template interpolation syntax is still used to construct strings from
> expressions when the template includes multiple interpolation sequences or a
> mixture of literal strings and interpolations. This deprecation applies only
> to templates that consist entirely of a single interpolation sequence.
> (and 3 more similar warnings elsewhere)

Since this syntax is already supported in 0.12 and everybody should have
upgraded to that till now, this change should be safe.