### PR TITLE
Add support for hermetic nixos configurations

### DIFF
--- a/deploy_nixos/main.tf
+++ b/deploy_nixos/main.tf
@@ -93,6 +93,12 @@ variable "target_system" {
   default     = "x86_64-linux"
 }
 
+variable "hermetic" {
+  type        = bool
+  description = "Treat the provided nixos configuration as a hermetic expression and do not evaluate using the ambient system nixpkgs. Useful if you customize eval-modules or use a pinned nixpkgs."
+  default     = false
+}
+
 # --------------------------------------------------------------------------
 
 locals {
@@ -122,7 +128,8 @@ data "external" "nixos-instantiate" {
     var.config_pwd == "" ? "." : var.config_pwd,
     # end of positional arguments
     # start of pass-through arguments
-    "--argstr", "system", var.target_system
+    "--argstr", "system", var.target_system,
+    "--arg", "hermetic", var.hermetic
     ],
     var.extra_eval_args,
   )

--- a/deploy_nixos/nixos-instantiate.sh
+++ b/deploy_nixos/nixos-instantiate.sh
@@ -19,17 +19,14 @@ command=(nix-instantiate --show-trace --expr '
       if hermetic
         then import configuration
         else import <nixpkgs/nixos> { inherit system configuration; };
-
-    inherit (os.pkgs) lib;
-
   in {
     inherit (builtins) currentSystem;
 
     substituters =
-      lib.concatStringsSep " " os.config.nix.binaryCaches;
+      builtins.concatStringsSep " " os.config.nix.binaryCaches;
 
     trusted-public-keys =
-      lib.concatStringsSep " " os.config.nix.binaryCachePublicKeys;
+      builtins.concatStringsSep " " os.config.nix.binaryCachePublicKeys;
 
     drv_path = os.system.drvPath;
     out_path = os.system;

--- a/examples/hermetic_config/configuration.nix
+++ b/examples/hermetic_config/configuration.nix
@@ -1,0 +1,60 @@
+# A simple, hermetic NixOS configuration for an AWS EC2 instance that
+# uses a nixpkgs pinned to a specific Git revision with an integrity
+# hash to ensure that we construct a NixOS system as purely as
+# possible.
+#
+# i.e. we explicitly specify which nixpkgs to use instead of relying
+# on the nixpkgs supplied on the NIX_PATH.
+#
+# The primary benefit of this is that it removes deployment surprises
+# when other developers supply a different nix-channel in the NIX_PATH
+# of their environment (even if you only add the 20.09 channel,
+# nix-channel --update can mutate that channel to a 20.09 with
+# backported changes).
+#
+# The secondary benefit is that you guard the `nixpkgs` you use, with
+# an integrity hash.
+let
+  nixpkgs =
+    let
+      rev = "cd63096d6d887d689543a0b97743d28995bc9bc3";
+      sha256 = "1wg61h4gndm3vcprdcg7rc4s1v3jkm5xd7lw8r2f67w502y94gcy";
+    in
+      builtins.fetchTarball {
+        url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+        inherit sha256;
+      };
+
+  system = "x86_64-linux";
+
+  configuration = { config, pkgs, ... }: {
+    imports = [
+      "${nixpkgs}/nixos/modules/virtualisation/amazon-image.nix"
+    ];
+
+    ec2.hvm = true;
+
+    networking.firewall.allowedTCPPorts = [ 22 80 ];
+
+    environment.systemPackages = [
+      pkgs.cloud-utils
+    ];
+
+    services.nginx = {
+      enable = true;
+      virtualHosts = {
+        "_" = {
+          root = pkgs.writeTextDir "html/index.html" ''
+            <html>
+              <body>
+                <h1>This is a hermetic NixOS configuration!</h1>
+              </body>
+            </html>
+          '';
+        };
+      };
+    };
+  };
+
+in
+  import "${nixpkgs}/nixos" { inherit system configuration; }

--- a/examples/hermetic_config/default.tf
+++ b/examples/hermetic_config/default.tf
@@ -1,0 +1,27 @@
+provider "aws" {
+  region  = "us-east-1"
+  profile = "yourprofile"
+}
+
+resource "aws_instance" "hermetic-nixos-system" {
+  count         = 1
+  ami           = "ami-068a62d478710462d" # NixOS 20.09 AMI
+
+  instance_type = "t2.micro"
+
+  key_name  = "yourkeyname"
+
+  tags = {
+    Name        = "hermetic-nixos-system-example"
+    Description = "An example of a hermetic NixOS system deployed by Terraform"
+  }
+}
+
+module "deploy_nixos" {
+  source               = "github.com/awakesecurity/terraform-nixos//deploy_nixos?ref=c4b1ee6d24b54e92fa3439a12bce349a6805bcdd"
+  nixos_config         = "${path.module}/configuration.nix"
+  hermetic             = true
+  target_user          = "root"
+  target_host          = aws_instance.hermetic-nixos-system[0].public_ip
+  ssh_private_key_file = pathexpand("~/.ssh/yourkeyname.pem")
+}


### PR DESCRIPTION
This change adds a Terraform variable `hermetic` and supporting logic to the Nix expression evaluated by `nix-instantiate` to better support users that need to evaluate configurations that supply their own pinned nixpkgs or wrap eval-modules to customize module special args.

e.g. at Awake we pin nixpkgs and build our NixOS configuration closures completely sealed from anything on the NIX_PATH. This change simply allows one to say "I'm supplying my own expression that results in a nixos system, so please use that".

A minor additional change was to further purify the Nix expression by using the supplied `pkgs.lib` from the derived NixOS system instead of effectfully re-importing <nixpkgs>.