### PR TITLE
Silence grep output and remove unused bash variable

### DIFF
--- a/deploy_nixos/nixos-instantiate.sh
+++ b/deploy_nixos/nixos-instantiate.sh
@@ -7,10 +7,6 @@ config=$2
 config_pwd=$3
 shift 3
 
-# Building the command
-nixExpression=<<EOF
-
-EOF
 
 command=(nix-instantiate --show-trace --expr '
   { system, configuration, hermetic ? false, ... }:
@@ -32,7 +28,7 @@ command=(nix-instantiate --show-trace --expr '
     out_path = os.system;
   }')
 
-if readlink --version | grep GNU; then
+if readlink --version | grep -q GNU; then
   readlink="readlink -f"
 else
   if command -v greadlink &> /dev/null; then


### PR DESCRIPTION
Fix for #46 

Adds `-q` parameter to `grep` to silence output so the output is not read by `terraform`.

Also deleted an unused bash variable just for cleanup.