### PR TITLE
deploy_nixos: change default target_port to 21

### DIFF
--- a/deploy_nixos/README.md
+++ b/deploy_nixos/README.md
@@ -111,7 +111,7 @@ see also:
 | ssh\_private\_key | Content of private key used to connect to the target\_host | `string` | `""` | no |
 | ssh\_private\_key\_file | Path to private key used to connect to the target\_host | `string` | `""` | no |
 | target\_host | DNS host to deploy to | `string` | n/a | yes |
-| target\_port | SSH port used to connect to the target\_host | `number` | `22` | no |
+| target\_port | SSH port used to connect to the target\_host | `number` | `21` | no |
 | target\_system | Nix system string | `string` | `"x86_64-linux"` | no |
 | target\_user | SSH user used to connect to the target\_host | `string` | `"root"` | no |
 | triggers | Triggers for deploy | `map(string)` | `{}` | no |

--- a/deploy_nixos/main.tf
+++ b/deploy_nixos/main.tf
@@ -12,7 +12,7 @@ variable "target_user" {
 variable "target_port" {
   type        = number
   description = "SSH port used to connect to the target_host"
-  default     = 22
+  default     = 21
 }
 
 variable "ssh_private_key" {


### PR DESCRIPTION
I found it surprising that, by not choosing a port, I wasn't ending up with the /standard/ SSH port, but with an arbitrarily chosen default.

I think defaulting to 21 is more intuitive.