### PR TITLE
Allow to pass arguments to a hermetic configuration if it's a function

### DIFF
--- a/deploy_nixos/README.md
+++ b/deploy_nixos/README.md
@@ -106,6 +106,7 @@ see also:
 | extra\_build\_args | List of arguments to pass to the nix builder | `list(string)` | `[]` | no |
 | extra\_eval\_args | List of arguments to pass to the nix evaluation | `list(string)` | `[]` | no |
 | hermetic | Treat the provided nixos configuration as a hermetic expression and do not evaluate using the ambient system nixpkgs. Useful if you customize eval-modules or use a pinned nixpkgs. | `bool` | false | no |
+| arguments | Attribute set passed to hermetic configuration if it is a function. | `map(any)` | `{}` | no |
 | keys | A map of filename to content to upload as secrets in /var/keys | `map(string)` | `{}` | no |
 | nixos\_config | Path to a NixOS configuration | `string` | `""` | no |
 | ssh\_agent | Whether to use an SSH agent. True if not ssh\_private\_key is passed | `bool` | `null` | no |

--- a/deploy_nixos/main.tf
+++ b/deploy_nixos/main.tf
@@ -81,6 +81,12 @@ variable "triggers" {
   default     = {}
 }
 
+variable "arguments" {
+  type        = map(any)
+  description = "A map of values to pass to the Nix expression. It only works form 'hermetic' configurations. For secrets, use 'keys' instead."
+  default     = {}
+}
+
 variable "keys" {
   type        = map(string)
   description = "A map of filename to content to upload as secrets in /var/keys"
@@ -129,7 +135,8 @@ data "external" "nixos-instantiate" {
     # end of positional arguments
     # start of pass-through arguments
     "--argstr", "system", var.target_system,
-    "--arg", "hermetic", var.hermetic
+    "--arg", "hermetic", var.hermetic,
+    "--argstr", "argumentsJson", jsonencode(var.arguments)
     ],
     var.extra_eval_args,
   )
@@ -197,4 +204,3 @@ output "id" {
   description = "random ID that changes on every nixos deployment"
   value       = null_resource.deploy_nixos.id
 }
-

--- a/deploy_nixos/nixos-instantiate.sh
+++ b/deploy_nixos/nixos-instantiate.sh
@@ -9,11 +9,19 @@ shift 3
 
 
 command=(nix-instantiate --show-trace --expr '
-  { system, configuration, hermetic ? false, ... }:
+  { system, configuration, hermetic ? false, argumentsJson, ... }:
   let
+    arguments = builtins.fromJSON argumentsJson;
+
     os =
       if hermetic
-        then import configuration
+        then
+          let
+            config = import configuration;
+          in
+          if builtins.isFunction config
+            then config arguments
+            else config
         else import <nixpkgs/nixos> { inherit system configuration; };
   in {
     inherit (builtins) currentSystem;


### PR DESCRIPTION
It adds a variable `arguments` which is passed to the result of `import configuration` (requires `hermetic`) if it's a function. So we can write a configuration like the following.

```
module "deploy_nixos" {
  source               = "github.com/tomferon/terraform-nixos//deploy_nixos?ref=8d095e9903380ffbe068f053090ad68dd31cc174"
  config               = "${path.module}/servers/serverA.nix"
  hermetic             = true
  # ...

  arguments = {
    vpnKeys = {
      serverB = wireguard_asymmetric_key.serverB.public_key
    }
  }

  keys = {
    wireguard_private_key = wireguard_asymmetric_key.serverA.private_key
  }
}
```

with `serverA.nix` such as

```
{ vpnKeys }:

let
  sources = import ./sources.nix;

in
import sources.nixos {
  configuration = {
    # Something using vpnKeys.serverB
  };
}
```