### PR TITLE
Add option to keep old generations

### DIFF
--- a/deploy_nixos/main.tf
+++ b/deploy_nixos/main.tf
@@ -99,6 +99,12 @@ variable "hermetic" {
   default     = false
 }
 
+variable "delete_older_than" {
+  type        = string
+  description = "Can be a list of generation numbers, the special value old to delete all non-current generations, a value such as 30d to delete all generations older than the specified number of days (except for the generation that was active at that point in time), or a value such as +5 to keep the last 5 generations ignoring any newer than current, e.g., if 30 is the current generation +5 will delete generation 25 and all older generations."
+  default     = "+1"
+}
+
 # --------------------------------------------------------------------------
 
 locals {
@@ -184,6 +190,7 @@ resource "null_resource" "deploy_nixos" {
       local.build_on_target,
       local.ssh_private_key == "" ? "-" : local.ssh_private_key,
       "switch",
+      var.delete_older_than,
       ],
       local.extra_build_args
     )

--- a/deploy_nixos/nixos-deploy.sh
+++ b/deploy_nixos/nixos-deploy.sh
@@ -33,7 +33,8 @@ targetPort="$4"
 buildOnTarget="$5"
 sshPrivateKey="$6"
 action="$7"
-shift 7
+deleteOlderThan="$8"
+shift 8
 
 # remove the last argument
 set -- "${@:1:$(($# - 1))}"
@@ -126,4 +127,7 @@ targetHostCmd "$outPath/bin/switch-to-configuration" "$action"
 
 # Cleanup previous generations
 log "collecting old nix derivations"
-targetHostCmd "nix-collect-garbage" "-d"
+# Deliberately not quoting $deleteOlderThan so the user can configure something like "1 2 3" 
+# to keep generations with those numbers
+targetHostCmd "nix-env" "--profile" "$profile" "--delete-generations" $deleteOlderThan
+targetHostCmd "nix-store" "--gc"


### PR DESCRIPTION
Fixes #36 

I hope these two commands do the same thing as `nix-collect-garbage -d`. I made the default to be the same behaviour as before (only keep the last generation)