### PR TITLE
Add Flakes support

### DIFF
--- a/deploy_nixos/README.md
+++ b/deploy_nixos/README.md
@@ -12,6 +12,8 @@ difference will be detected on the next "terraform plan".
 
 Either pass a "config" which is a dynamic nixos configuration and a
 "config_pwd", or a "nixos_config", a path to a nixos configuration.nix file.
+If you have defined your NixOs configuration in a Flake, use "nixos_config" 
+to specify the name of the attribue and set "flake" to true.
 
 ### Secret handling
 
@@ -106,6 +108,7 @@ see also:
 | extra\_build\_args | List of arguments to pass to the nix builder | `list(string)` | `[]` | no |
 | extra\_eval\_args | List of arguments to pass to the nix evaluation | `list(string)` | `[]` | no |
 | hermetic | Treat the provided nixos configuration as a hermetic expression and do not evaluate using the ambient system nixpkgs. Useful if you customize eval-modules or use a pinned nixpkgs. | `bool` | false | no |
+| flake | Treat the provided nixos_config as the name of the NixOS configuration to use in the flake located in the current directory. Useful if you customize eval-modules or use a pinned nixpkgs. | `bool` | false | no |
 | keys | A map of filename to content to upload as secrets in /var/keys | `map(string)` | `{}` | no |
 | nixos\_config | Path to a NixOS configuration | `string` | `""` | no |
 | ssh\_agent | Whether to use an SSH agent. True if not ssh\_private\_key is passed | `bool` | `null` | no |

--- a/deploy_nixos/main.tf
+++ b/deploy_nixos/main.tf
@@ -99,6 +99,12 @@ variable "hermetic" {
   default     = false
 }
 
+variable "flake" {
+  type        = bool
+  description = "Treat the provided nixos_config as the NixOS configuration to use in the flake located in the current directory"
+  default     = false
+}
+
 variable "delete_older_than" {
   type        = string
   description = "Can be a list of generation numbers, the special value old to delete all non-current generations, a value such as 30d to delete all generations older than the specified number of days (except for the generation that was active at that point in time), or a value such as +5 to keep the last 5 generations ignoring any newer than current, e.g., if 30 is the current generation +5 will delete generation 25 and all older generations."
@@ -132,6 +138,7 @@ data "external" "nixos-instantiate" {
     var.NIX_PATH == "" ? "-" : var.NIX_PATH,
     var.config != "" ? var.config : var.nixos_config,
     var.config_pwd == "" ? "." : var.config_pwd,
+    var.flake,
     # end of positional arguments
     # start of pass-through arguments
     "--argstr", "system", var.target_system,


### PR DESCRIPTION
This change adds basic support for flakes.

It works but I'm unsure about the approach:
I've added an optional `flake` parameter, when set to true it will consider the value of `nixos_config` to be the name of the attribute to lookup in the `nixosConfiguration` output of the flake located in the same folder as the Terraform config.