### PR TITLE
Parameterize remote ssh connection timeout

### DIFF
--- a/deploy_nixos/README.md
+++ b/deploy_nixos/README.md
@@ -118,6 +118,7 @@ see also:
 | target\_port | SSH port used to connect to the target\_host | `number` | `22` | no |
 | target\_system | Nix system string | `string` | `"x86_64-linux"` | no |
 | target\_user | SSH user used to connect to the target\_host | `string` | `"root"` | no |
+| timeout | Remote ssh connection timeout | `string` | `"100s"` | no |
 | triggers | Triggers for deploy | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/deploy_nixos/main.tf
+++ b/deploy_nixos/main.tf
@@ -111,6 +111,12 @@ variable "delete_older_than" {
   default     = "+1"
 }
 
+variable "timeout" {
+  type        = string
+  description = "Remote connection timeout."
+  default     = "100s"
+}
+
 # --------------------------------------------------------------------------
 
 locals {
@@ -157,7 +163,7 @@ resource "null_resource" "deploy_nixos" {
     port        = var.target_port
     user        = var.target_user
     agent       = local.ssh_agent
-    timeout     = "100s"
+    timeout     = var.timeout
     private_key = local.ssh_private_key == "-" ? "" : local.ssh_private_key
   }
 

--- a/deploy_nixos/main.tf
+++ b/deploy_nixos/main.tf
@@ -113,7 +113,7 @@ variable "delete_older_than" {
 
 variable "timeout" {
   type        = string
-  description = "Remote connection timeout."
+  description = "Remote ssh connection timeout."
   default     = "100s"
 }
 


### PR DESCRIPTION
This is a pretty simple one; just expose the `connection` `timeout` parameter using the current value as a default. I've used these changes from my branch without any problems.

Thanks for the great module!