### PR TITLE
Use IdentitiesOnly=yes for nixos-deploy

### DIFF
--- a/deploy_nixos/nixos-deploy.sh
+++ b/deploy_nixos/nixos-deploy.sh
@@ -20,6 +20,8 @@ sshOpts=(
   -o "GlobalKnownHostsFile=/dev/null"
   # interactive authentication is not possible
   -o "BatchMode=yes"
+  # prevent authentication failures when the user has too many keys
+  -o "IdentitiesOnly=yes"
   # verbose output for easier debugging
   -v
 )


### PR DESCRIPTION
This PR adds `IdentitiesOnly=yes` into the SSH arguments for `nixos-deploy.sh`. This fixes some cases where the user has too many keys, and SSH only puts the specified key in the Terraform file last.