### PR TITLE
Hermetic configuration are not to be imported with deploy_nixos

### DIFF
--- a/deploy_nixos/nixos-instantiate.sh
+++ b/deploy_nixos/nixos-instantiate.sh
@@ -27,7 +27,7 @@ command=(nix-instantiate --show-trace --expr '
       if flake
          then importFromFlake { nixosConfig = configuration; }
          else if hermetic
-          then import configuration
+          then configuration
           else import <nixpkgs/nixos> { inherit system configuration; };
   in {
     inherit (builtins) currentSystem;


### PR DESCRIPTION
My understanding is that I should be able to write something like this:

```
module “deploy_nixos” {
  # …
  hermetic = true
  config_pwd = “${path.module}/../somewhere”
  config = <<-EOF
    (import ./something.nix) {
      var1 = “${var.variable1}”;
    }
EOF
}
```

For this to be possible, hermetic configuration using `config` rather than `config_file` should not be imported as far as I can tell.