### PR TITLE
deploy_nixos: parameterise concurrency controls of `nix-copy-closure`

### DIFF
--- a/deploy_nixos/README.md
+++ b/deploy_nixos/README.md
@@ -107,6 +107,7 @@ see also:
 | config\_pwd | Directory to evaluate the configuration in. This argument is required if 'config' is given | `string` | `""` | no |
 | extra\_build\_args | List of arguments to pass to the nix builder | `list(string)` | `[]` | no |
 | extra\_eval\_args | List of arguments to pass to the nix evaluation | `list(string)` | `[]` | no |
+| closure\_copy\_concurrency | Concurrency used when transferring derivations to the remote host | `number` | `1` | no |
 | hermetic | Treat the provided nixos configuration as a hermetic expression and do not evaluate using the ambient system nixpkgs. Useful if you customize eval-modules or use a pinned nixpkgs. | `bool` | false | no |
 | flake | Treat the provided nixos_config as the name of the NixOS configuration to use in the flake located in the current directory. Useful if you customize eval-modules or use a pinned nixpkgs. | `bool` | false | no |
 | keys | A map of filename to content to upload as secrets in /var/keys | `map(string)` | `{}` | no |

--- a/deploy_nixos/main.tf
+++ b/deploy_nixos/main.tf
@@ -69,6 +69,12 @@ variable "extra_build_args" {
   default     = []
 }
 
+variable "closure_copy_concurrency" {
+  type        = number
+  description = "Concurrency to apply when copying derivations to the target_host"
+  default     = 1
+}
+
 variable "build_on_target" {
   type        = string
   description = "Avoid building on the deployer. Must be true or false. Has no effect when deploying from an incompatible system. Unlike remote builders, this does not require the deploying user to be trusted by its host."
@@ -198,6 +204,7 @@ resource "null_resource" "deploy_nixos" {
       local.ssh_private_key == "" ? "-" : local.ssh_private_key,
       "switch",
       var.delete_older_than,
+      var.closure_copy_concurrency,
       ],
       local.extra_build_args
     )

--- a/deploy_nixos/nixos-deploy.sh
+++ b/deploy_nixos/nixos-deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # nixos-deploy deploys a nixos-instantiate-generated drvPath to a target host
 #
-# Usage: nixos-deploy.sh <drvPath> <host> <switch-action> <deleteOlderThan> [<build-opts>] ignoreme
+# Usage: nixos-deploy.sh <drvPath> <host> <switch-action> <deleteOlderThan> <copyConcurrency> [<build-opts>] ignoreme
 set -euo pipefail
 
 ### Defaults ###
@@ -34,7 +34,8 @@ buildOnTarget="$5"
 sshPrivateKey="$6"
 action="$7"
 deleteOlderThan="$8"
-shift 8
+copyConcurrency="$9"
+shift 9
 
 # remove the last argument
 set -- "${@:1:$(($# - 1))}"
@@ -59,7 +60,7 @@ log() {
 }
 
 copyToTarget() {
-  NIX_SSHOPTS="${sshOpts[*]}" nix-copy-closure --to "$targetHost" "$@"
+  NIX_SSHOPTS="${sshOpts[*]}" nix-copy-closure --max-jobs "$copyConcurrency" --to "$targetHost" "$@"
 }
 
 # assumes that passwordless sudo is enabled on the server

--- a/deploy_nixos/nixos-deploy.sh
+++ b/deploy_nixos/nixos-deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # nixos-deploy deploys a nixos-instantiate-generated drvPath to a target host
 #
-# Usage: nixos-deploy.sh <drvPath> <host> <switch-action> [<build-opts>] ignoreme
+# Usage: nixos-deploy.sh <drvPath> <host> <switch-action> <deleteOlderThan> [<build-opts>] ignoreme
 set -euo pipefail
 
 ### Defaults ###


### PR DESCRIPTION
I often use this module to provision cloud machines that are incompatible with the host machine I am deploying from. In these cases, I often find that the slowest part is transferring `.drv` files to the remote machine, where they are then evaluated and built.

This change exposes the `--max-jobs` parameter of `nix-copy-closure` to the terraform operator as a variable, so more than one derivation can be copied to the remote host at a time. This isn't officially documented in `--help`/the man page of `nix-copy-closure`, but appears to be supported.

```
$ nix-copy-closure --max-jobs invalid
error: configuration setting 'max-jobs' should be 'auto' or an integer
Try 'nix-copy-closure --help' for more information.
```

In practice, this significantly improved my runtimes when deploying from incompatible host systems.