### PR TITLE
allow passing specialArgs

### DIFF
--- a/deploy_nixos/nixos-instantiate.sh
+++ b/deploy_nixos/nixos-instantiate.sh
@@ -10,7 +10,7 @@ shift 4
 
 
 command=(nix-instantiate --show-trace --expr '
-  { system, configuration, hermetic ? false, flake ? false, ... }:
+  { system, configuration, hermetic ? false, flake ? false, specialArgs ? {}, ... }:
   let
     importFromFlake = { nixosConfig }:
         let
@@ -28,7 +28,10 @@ command=(nix-instantiate --show-trace --expr '
          then importFromFlake { nixosConfig = configuration; }
          else if hermetic
           then import configuration
-          else import <nixpkgs/nixos> { inherit system configuration; };
+          else import <nixpkgs/nixos/lib/eval-config.nix> {
+            inherit system specialArgs;
+            modules = [ configuration ];
+          };
   in {
     inherit (builtins) currentSystem;
 


### PR DESCRIPTION
closes #77.

exposes `specialArgs`.

## usage

## passing values just from TF

```tf
extra_build_args = [
  "--arg",
  "specialArgs",
  <<-EOT
    builtins.fromJSON ''${jsonencode({
      # TF map of keys to pass to each nixos module
      my = local.cool_value
    })}''
  EOT
]
```

## passing values from both nix and TF

```tf
extra_build_args = [
  "--arg",
  "specialArgs",
  <<-EOT
    {
      # keys to add to each 
      my_cool = "nix string";
      # but here's why we're here: values from TF!
      much_tofu = builtins.fromJSON ''${jsonencode({
        # TF map of keys to pass to each nixos module
        my = local.cool_value
      })}'';
    }
  EOT
]
```

## prerequisites

- `flake = false`
- `hermetic = false`
