### PR TITLE
allow passing env vars to deployment

### DIFF
--- a/deploy_nixos/main.tf
+++ b/deploy_nixos/main.tf
@@ -111,6 +111,12 @@ variable "delete_older_than" {
   default     = "+1"
 }
 
+variable "deploy_environment" {
+  type        = map(string)
+  description = "Extra environment variables to be set during deployment."
+  default     = {}
+}
+
 # --------------------------------------------------------------------------
 
 locals {
@@ -188,6 +194,7 @@ resource "null_resource" "deploy_nixos" {
 
   # do the actual deployment
   provisioner "local-exec" {
+    environment = var.deploy_environment
     interpreter = concat([
       "${path.module}/nixos-deploy.sh",
       data.external.nixos-instantiate.result["drv_path"],


### PR DESCRIPTION
adds an input variable `deploy_environment` to the `deploy_nixos` module, allowing one to pass environment variables to the `nixos-deploy.sh` script.

i found a use for this myself to pass the `SSH_AUTH_SOCK` environment variable needed for ssh (c.f. #6), when reproducing the TF environment using nix.

edit: [similar commit](https://github.com/smulikHakipod/terraform-nixos/commit/4caabad508b14267bf95ac0af1950fc08b9470c0)
